### PR TITLE
Add Options Construction

### DIFF
--- a/examples/using-handlers/main.go
+++ b/examples/using-handlers/main.go
@@ -32,7 +32,7 @@ func main() {
 	engine := gin.Default()
 	engine.Use(sessions.SessionsMany([]string{oauthSessionName}, sessionStore))
 
-	oh := handlers.NewOauthHandlers(
+	oh, err := handlers.NewOauthHandlers(
 		oidcProvider,
 		oauthClientID,
 		oauthClientSecret,
@@ -42,6 +42,9 @@ func main() {
 		oauthSessionName,
 		oauthScopes,
 	)
+	if err != nil {
+		panic(err)
+	}
 
 	// These three handlers  need to be setup for OAUTH to work.
 	engine.GET("/oauth/login", oh.HandleLogin)

--- a/handlers/construction.go
+++ b/handlers/construction.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+type OauthHandlers struct {
+	oauthLogoutUrl     string
+	oauthRevocationUrl string
+	oauthPKCESecret    string
+	oauthSessionName   string
+	oauth2config       *oauth2.Config
+	verifier           *oidc.IDTokenVerifier
+}
+
+// OauthHandlers holds the configuration used by an Oauth/Oidc Client.
+// oidcProvider:
+//
+//	This is the oidc discovery URL. Your OIDC provider shuold inform you what this URL should be.
+//	The client will pull a configuration file at <oidcProvider>/.well-known/openid-configuration.
+//
+// oauthClientID:
+//
+//	This is a unique identifier representing account this application has with your oauth provider.
+//
+// oauthClientSecret:
+//
+//	Your application's password with the oauth provider. This is secret. Don't give it to anyone.
+//
+// oauthRedirectUrl:
+//
+//	This is sometiems also called the "callback" url. When you register your application with
+//	the oauth provider, you will have to inform them what the redirect URL is, and we need to pass
+//	the same URL. It should be set to the URL where users can connect to your application where the
+//	HandleRedirect handler is listening.
+//
+// oauthLogoutUrl:
+//
+//	Where should users go after they log out? Check if your oauth provider has a logout endpoint.
+//	If they do, you should set that URL here. If set to an empty string, I'll try to figure it out
+//	using the openidc provider metadata. No promises.
+//
+// oauthPKCESecret:
+//
+//	PKCE (RFC7636) is a good security practice. The general idea is that in the first Oauth phase,
+//	we pass a hash sum to the auth server. Then, when we do token exchange we pass the original data.
+//	The auth server can then know that both requests came from the same place. Generally, you have to
+//	store this data somehow. In this implementation, we are stuffing this data into the state and
+//	encrypting it. This is the encryption key. This is an implementation detail.
+//
+// oauthSessionName:
+//
+//	We're using gin-contrib/sessions to store the oidc idtoken and other data to the session. You should
+//	create a session using whatever storage medium you wish. Use encryption if able. Use this variable
+//	to tell us which session you want login information to be stored.
+//
+// oauthScopes:
+//
+//	A list of scopes we should request the auth server to send us. Just because you request it, doesn't
+//	mean the auth server will oblige. Your oauth server documentation will tell you what scopes are
+//	available. When you add additional scopes, the auth server will return additional claims
+//	during token exchange. The content of the claims are various. If you use the MiddlewareRequireLogin,
+//	you will find the claims are made available as a gin context value.
+func NewOauthHandlers(
+	oidcProvider,
+	oauthClientID,
+	oauthClientSecret,
+	oauthRedirectUrl,
+	oauthLogoutUrl,
+	oauthPKCESecret,
+	oauthSessionName string,
+	oauthScopes []string) (*OauthHandlers, error) {
+
+	opts := []OauthHandlersOption{
+		WithOauthSessionName(oauthSessionName),
+		WithOauthPKCESecret(oauthPKCESecret),
+	}
+	provider, err := oidc.NewProvider(context.Background(), oidcProvider)
+	if err != nil {
+		return nil, err
+	}
+	claims := make(map[string]any)
+	provider.Claims(&claims)
+	if oauthLogoutUrl == "" {
+		// This key is *not* in the documented provider metadata
+		// https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+		// However, sometimes it is used.
+		if val, ok := claims["end_session_endpoint"].(string); ok {
+			oauthLogoutUrl = val
+		} else {
+			oauthLogoutUrl = "/"
+		}
+	}
+	opts = append(opts, WithOauthLogoutUrl(oauthLogoutUrl))
+	// Sometimes, there is a revocation endpoint. Sometimes.
+	// This endpoint can be used to revoke individual tokens.
+	if val, ok := claims["revocation_endpoint"].(string); ok {
+		opts = append(opts, WithOauthRevocationUrl(val))
+	}
+	oauth2config := &oauth2.Config{
+		ClientID:     oauthClientID,
+		ClientSecret: oauthClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  oauthRedirectUrl,
+		Scopes:       append([]string{oidc.ScopeOpenID}, oauthScopes...),
+	}
+	opts = append(opts, WithOauth2Config(oauth2config))
+	verifier := provider.Verifier(&oidc.Config{
+		ClientID: oauth2config.ClientID,
+	})
+	opts = append(opts, WithVerifier(verifier))
+	return NewOauthHandlersWithOptions(opts...)
+}
+
+func NewOauthHandlersWithOptions(opts ...OauthHandlersOption) (*OauthHandlers, error) {
+	oh := new(OauthHandlers)
+	for _, opt := range opts {
+		if err := opt(oh); err != nil {
+			return nil, err
+		}
+	}
+	return oh, nil
+}
+
+type OauthHandlersOption (func(*OauthHandlers) error)
+
+func WithOauthLogoutUrl(logoutUrl string) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.oauthLogoutUrl = logoutUrl
+		return nil
+	}
+}
+
+func WithOauthRevocationUrl(revocationUrl string) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.oauthRevocationUrl = revocationUrl
+		return nil
+	}
+}
+
+func WithOauthPKCESecret(pkcesecret string) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.oauthPKCESecret = pkcesecret
+		return nil
+	}
+}
+
+func WithOauthSessionName(sessionName string) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.oauthSessionName = sessionName
+		return nil
+	}
+}
+
+func WithOauth2Config(oauth2config *oauth2.Config) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.oauth2config = oauth2config
+		return nil
+	}
+}
+
+func WithVerifier(verifier *oidc.IDTokenVerifier) OauthHandlersOption {
+	return func(oh *OauthHandlers) error {
+		oh.verifier = verifier
+		return nil
+	}
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -171,7 +171,7 @@ func TestCSRFMitigation(t *testing.T) {
 	authServer := fakeOauthServer(t, redirect, clientId)
 	defer authServer.Close()
 	t.Logf("Starting auth server at %s", authServer.URL)
-	handlers := NewOauthHandlers(
+	handlers, err := NewOauthHandlers(
 		authServer.URL+"/oidc",
 		clientId,
 		"clientSecret123456",
@@ -181,6 +181,9 @@ func TestCSRFMitigation(t *testing.T) {
 		"loginSession",
 		nil,
 	)
+	if err != nil {
+		t.Fatalf("failed to create handlers: %v", err)
+	}
 	eng := gin.Default()
 	memsessions := cookie.NewStore(random32(), random32())
 	eng.Use(sessions.SessionsMany([]string{"loginSession"}, memsessions))


### PR DESCRIPTION
This separates the construction logic  into a separate file and adds "options" style construction.

The original constructor now returns an error rather than panicking if the options are invlaid.
This was happening, for example, when OIDC endpoints were not setup.
